### PR TITLE
when applied database.api + database.neo4j will contain OSGi Manifests

### DIFF
--- a/database/api/build.gradle
+++ b/database/api/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 }
 
 apply plugin: 'maven'
+apply plugin: 'osgi'
 
 configure(install.repositories.mavenInstaller) {
     pom.project {
@@ -24,5 +25,11 @@ configure(install.repositories.mavenInstaller) {
 jar {
     manifest {
         name = 'Database API'
+        symbolicName = "com.neueda.graphdb.database.${project.name}"
+        instruction 'Export-Package', "*;version=${version};-noimport:=true"
+        instruction 'Bundle-Vendor', 'neueda.lv'
+        instruction '-removeheaders', 'Tool, Bnd-LastModified'
+        instruction '-nouses', 'true'
+        // instruction '-snapshot', '${tstamp}'
     }
 }

--- a/database/api/build.gradle
+++ b/database/api/build.gradle
@@ -2,3 +2,27 @@ dependencies {
     testCompile "junit:junit:$versionJunit"
     testCompile "org.assertj:assertj-core:$versionAssertj"
 }
+
+apply plugin: 'maven'
+
+configure(install.repositories.mavenInstaller) {
+    pom.project {
+        // groupId 'com.neueda.graphdb'
+        // artifactId 'graphdb-api'
+        inceptionYear '2016'
+        packaging 'jar'
+        licenses {
+            license {
+                name 'The Apache Software License, Version 2.0'
+                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                distribution 'repo'
+            }
+        }
+    }
+}
+
+jar {
+    manifest {
+        name = 'Database API'
+    }
+}

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -1,2 +1,19 @@
 dependencies {
 }
+
+allprojects {
+
+    apply plugin: 'osgi'
+
+    jar {
+        manifest {
+            symbolicName = "com.neueda.graphdb.database.${project.name}"
+            instruction 'Export-Package', "*;version=${version};-noimport:=true"
+            instruction 'Bundle-Vendor', 'neueda.lv'
+            instruction '-removeheaders', 'Tool, Bnd-LastModified'
+            instruction '-nouses', 'true'
+            // instruction '-snapshot', '${tstamp}'
+        }
+    }
+
+}

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -1,19 +1,2 @@
 dependencies {
 }
-
-allprojects {
-
-    apply plugin: 'osgi'
-
-    jar {
-        manifest {
-            symbolicName = "com.neueda.graphdb.database.${project.name}"
-            instruction 'Export-Package', "*;version=${version};-noimport:=true"
-            instruction 'Bundle-Vendor', 'neueda.lv'
-            instruction '-removeheaders', 'Tool, Bnd-LastModified'
-            instruction '-nouses', 'true'
-            // instruction '-snapshot', '${tstamp}'
-        }
-    }
-
-}

--- a/database/neo4j/build.gradle
+++ b/database/neo4j/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 }
 
 apply plugin: 'maven'
+apply plugin: 'osgi'
 
 configure(install.repositories.mavenInstaller) {
     pom.project {
@@ -24,5 +25,11 @@ configure(install.repositories.mavenInstaller) {
 jar {
     manifest {
         name = 'Database Neo4j'
+        symbolicName = "com.neueda.graphdb.database.${project.name}"
+        instruction 'Export-Package', "*;version=${version};-noimport:=true"
+        instruction 'Bundle-Vendor', 'neueda.lv'
+        instruction '-removeheaders', 'Tool, Bnd-LastModified'
+        instruction '-nouses', 'true'
+        // instruction '-snapshot', '${tstamp}'
     }
 }

--- a/database/neo4j/build.gradle
+++ b/database/neo4j/build.gradle
@@ -2,3 +2,27 @@ dependencies {
     compile project(':database:api')
     compile "org.neo4j.driver:neo4j-java-driver:$versionNeo4jJavaBoltDriver"
 }
+
+apply plugin: 'maven'
+
+configure(install.repositories.mavenInstaller) {
+    pom.project {
+        // groupId 'com.neueda.graphdb'
+        // artifactId 'graphdb-neo4j'
+        inceptionYear '2016'
+        packaging 'jar'
+        licenses {
+            license {
+                name 'The Apache Software License, Version 2.0'
+                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                distribution 'repo'
+            }
+        }
+    }
+}
+
+jar {
+    manifest {
+        name = 'Database Neo4j'
+    }
+}


### PR DESCRIPTION
I would like to reuse the database.* projects (currently database.api + database.neo4j) in an OSGi environment. I'm not an Gradle expert, so please verify the setup. Additional I added a plugin to install the artifacts into local Maven repository.