### PR TITLE
Travis publish support (2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ allprojects {
     }
 }
 
+test {
+    systemProperty 'graphDatabaseSupportDevelopment', 'true'
+}
+
 release {
     failOnCommitNeeded = true
     failOnPublishNeeded = true
@@ -57,9 +61,9 @@ release {
 
     tagTemplate = '${version}'
     preCommitText = '[release]'
-    preTagCommitMessage = ' Pre tag commit: '
+    preTagCommitMessage = ' [skip ci] Pre tag commit: '
     tagCommitMessage = ' Creating tag: '
-    newVersionCommitMessage = ' New version commit: '
+    newVersionCommitMessage = ' [skip ci] New version commit: '
 
     git {
         requireBranch = 'master'

--- a/graph-database-support-plugin/build.gradle
+++ b/graph-database-support-plugin/build.gradle
@@ -26,6 +26,9 @@ intellij {
 
     def homePath = System.properties['user.home']
     sandboxDirectory "${homePath}/.intellij/graphdb"
+}
+
+runIde {
     systemProperty 'graphDatabaseSupportDevelopment', 'true'
 }
 

--- a/graph-database-support-plugin/build.gradle
+++ b/graph-database-support-plugin/build.gradle
@@ -15,7 +15,6 @@ intellij {
     publishPlugin {
         username System.getenv("INTELLIJ_USERNAME")
         password System.getenv("INTELLIJ_PASSWORD")
-        channels 'experimental'
     }
 
     if (System.getenv("CI_SERVER") == "yes") {


### PR DESCRIPTION
After this small update, `./gradlew release` is the only command required to execute in order to publish an update to Jetbrains Plugin Repository, and the plugin will get published on Stable channel.  
If a bad update happened, unlist the update in JPR and run `./gradlew release` again with a new version.  

JPR publishing is activated by adding/changing a version tag on a commit in **neueda/jetbrains-plugin-graph-database-support** master.